### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,24 @@
 sudo: false
+dist: trusty
+language: cpp
 
-language:
-  - cpp
+# Have to install g++7 to upgrade libstdc++
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode10.1
+
 
 before_install:
-  - pip install --user cpp-coveralls
+  - eval "${MATRIX_EVAL}"
 
 script:
   - mkdir build
   - cd build
   - cmake ..
-  - cmake --build .
+  - make -j$(nproc --all)
   - ctest
 
-after_success:
-  - coveralls --root .. -E ".*external.*" -E ".*CMakeFiles.*" -E ".*test/.*.cpp.*"
-
 notifications:
-email: false
+  email: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.9.2)
 project (autotester)
 
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${PROJECT_SOURCE_DIR}/cmake")


### PR DESCRIPTION
Only know how to make it work for OSX, travis builds fail on linux dists with:

Example: https://travis-ci.org/CS3203-14/SPA/jobs/484718727
```
/mnt/c/g/autotester/src/autotester/src/AutoTester.cpp:40: undefined reference to `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::c_str() const'
```

Related links:
https://stackoverflow.com/questions/33394934/converting-std-cxx11string-to-stdstring